### PR TITLE
change the readme to list some unsupported roms

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Currently tested on:
 
 Currently NOT working on:
 - Android <= 10
+- Samsung Oneui
+- OnePlus OxygenOS
+- Tecno HiOS
+- most other non AOSP
 
 It *should* also work on other architectures .
 


### PR DESCRIPTION
It seems, that this module is broken in some not aosp roms.
For example Samsung, HiOS and OxygenOS dont work. 

With this change it would be easier to directly see: "ah its not supported"