### PR TITLE
fix: execute commands via app broadcast to bypass system_server su re…

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,11 +25,8 @@
 
         <receiver
             android:name=".CommandReceiver"
-            android:exported="true">
-            <intent-filter>
-                <action android:name="com.leohearts.alternativeUnlockHook.EXECUTE" />
-            </intent-filter>
-        </receiver>
+            android:exported="true"
+            android:permission="android.permission.STATUS_BAR_SERVICE" />
 
         <meta-data
             android:name="xposedmodule"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,6 +23,14 @@
             </intent-filter>
         </activity>
 
+        <receiver
+            android:name=".CommandReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.leohearts.alternativeUnlockHook.EXECUTE" />
+            </intent-filter>
+        </receiver>
+
         <meta-data
             android:name="xposedmodule"
             android:value="true" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,6 +25,7 @@
 
         <receiver
             android:name=".CommandReceiver"
+            android:directBootAware="true"
             android:exported="true"
             android:permission="android.permission.STATUS_BAR_SERVICE" />
 

--- a/app/src/main/java/com/leohearts/alternativeUnlockHook/CommandReceiver.kt
+++ b/app/src/main/java/com/leohearts/alternativeUnlockHook/CommandReceiver.kt
@@ -1,0 +1,30 @@
+package com.leohearts.alternativeUnlockHook
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+
+class CommandReceiver : BroadcastReceiver() {
+    private val tag = "alternativeUnlockHook"
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != "com.leohearts.alternativeUnlockHook.EXECUTE") return
+        val command = intent.getStringExtra("command") ?: return
+        val type = intent.getStringExtra("type") ?: "sh"
+        Log.i(tag, "CommandReceiver: executing command=$command type=$type")
+        Thread {
+            try {
+                val proc = if (type == "sudo") {
+                    Runtime.getRuntime().exec(arrayOf("su", "-c", command))
+                } else {
+                    Runtime.getRuntime().exec(arrayOf("sh", "-c", command))
+                }
+                val exit = proc.waitFor()
+                Log.i(tag, "CommandReceiver: exited with $exit")
+            } catch (e: Exception) {
+                Log.e(tag, "CommandReceiver: failed", e)
+            }
+        }.start()
+    }
+}

--- a/app/src/main/java/com/leohearts/alternativeUnlockHook/CommandReceiver.kt
+++ b/app/src/main/java/com/leohearts/alternativeUnlockHook/CommandReceiver.kt
@@ -13,6 +13,7 @@ class CommandReceiver : BroadcastReceiver() {
         val command = intent.getStringExtra("command") ?: return
         val type = intent.getStringExtra("type") ?: "sh"
         Log.i(tag, "CommandReceiver: executing command=$command type=$type")
+        val pendingResult = goAsync()
         Thread {
             try {
                 val proc = if (type == "sudo") {
@@ -24,7 +25,9 @@ class CommandReceiver : BroadcastReceiver() {
                 Log.i(tag, "CommandReceiver: exited with $exit")
             } catch (e: Exception) {
                 Log.e(tag, "CommandReceiver: failed", e)
+            } finally {
+                pendingResult.finish()
             }
-        }.start()
+        }.apply { name = "CommandReceiver" }.start()
     }
 }

--- a/app/src/main/java/com/leohearts/alternativeUnlockHook/HookClass.java
+++ b/app/src/main/java/com/leohearts/alternativeUnlockHook/HookClass.java
@@ -95,7 +95,10 @@ public class HookClass implements IXposedHookLoadPackage {
                         android.content.Context ctx = (android.content.Context)
                             XposedHelpers.callMethod(activityThread, "getSystemContext");
                         Intent intent = new Intent("com.leohearts.alternativeUnlockHook.EXECUTE");
-                        intent.setPackage("com.leohearts.alternativeUnlockHook");
+                        intent.setClassName(
+                            "com.leohearts.alternativeUnlockHook",
+                            "com.leohearts.alternativeUnlockHook.CommandReceiver"
+                        );
                         intent.putExtra("command", actionCommand);
                         intent.putExtra("type", actionType);
                         ctx.sendBroadcast(intent);

--- a/app/src/main/java/com/leohearts/alternativeUnlockHook/HookClass.java
+++ b/app/src/main/java/com/leohearts/alternativeUnlockHook/HookClass.java
@@ -8,6 +8,7 @@ import de.robv.android.xposed.callbacks.XC_LoadPackage;
 
 import android.annotation.SuppressLint;
 import android.content.Intent;
+import android.os.Process;
 import android.util.Log;
 
 import java.io.FileNotFoundException;
@@ -99,9 +100,10 @@ public class HookClass implements IXposedHookLoadPackage {
                             "com.leohearts.alternativeUnlockHook",
                             "com.leohearts.alternativeUnlockHook.CommandReceiver"
                         );
+                        intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
                         intent.putExtra("command", actionCommand);
                         intent.putExtra("type", actionType);
-                        ctx.sendBroadcast(intent);
+                        ctx.sendBroadcastAsUser(intent, Process.myUserHandle());
                         Log.i(TAG, "broadcast sent: " + actionCommand);
                     } catch (Exception e) {
                         Log.e(TAG, "broadcast failed: " + e.getMessage(), e);

--- a/app/src/main/java/com/leohearts/alternativeUnlockHook/HookClass.java
+++ b/app/src/main/java/com/leohearts/alternativeUnlockHook/HookClass.java
@@ -7,12 +7,11 @@ import de.robv.android.xposed.XposedHelpers;
 import de.robv.android.xposed.callbacks.XC_LoadPackage;
 
 import android.annotation.SuppressLint;
+import android.content.Intent;
 import android.util.Log;
 
 import java.io.FileNotFoundException;
 import java.io.FileReader;
-import java.io.IOException;
-import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.Properties;
@@ -36,15 +35,6 @@ public class HookClass implements IXposedHookLoadPackage {
     private String actionType = "sh";
     private String actionCommand = "whoami";
     private String dynamicLoad = "false";
-
-    public Process sudo(String cmd) throws IOException {
-        Log.i(TAG, "sudo: " + cmd);
-        return Runtime.getRuntime().exec(new String[]{"su", "-c", cmd});
-    }
-    public Process system(String cmd) throws IOException {
-        Log.i(TAG, "system: " + cmd);
-        return Runtime.getRuntime().exec(new String[]{"sh", "-c", cmd});
-    }
 
     @SuppressLint("SdCardPath")
     public void initConfig(){
@@ -98,12 +88,21 @@ public class HookClass implements IXposedHookLoadPackage {
                 if (credStr.equals(fakePassword)){
                     Log.i(TAG, "replaceCred: detected");
                     try {
-                        if (actionType.contains("sh")) { // foolproof
-                            system(actionCommand);
-                        } else if (actionType.contains("sudo")) {
-                            sudo(actionCommand);
-                        }
-                    } catch (Exception ignored) {}
+                        Object activityThread = XposedHelpers.callStaticMethod(
+                            XposedHelpers.findClass("android.app.ActivityThread", null),
+                            "currentActivityThread"
+                        );
+                        android.content.Context ctx = (android.content.Context)
+                            XposedHelpers.callMethod(activityThread, "getSystemContext");
+                        Intent intent = new Intent("com.leohearts.alternativeUnlockHook.EXECUTE");
+                        intent.setPackage("com.leohearts.alternativeUnlockHook");
+                        intent.putExtra("command", actionCommand);
+                        intent.putExtra("type", actionType);
+                        ctx.sendBroadcast(intent);
+                        Log.i(TAG, "broadcast sent: " + actionCommand);
+                    } catch (Exception e) {
+                        Log.e(TAG, "broadcast failed: " + e.getMessage(), e);
+                    }
                     // replace with real password
                     param.args[0] = XposedHelpers.newInstance(mCredential.getClass(), credType, (CharSequence) realPassword);
                     // this is the hacky way for less stability but more compatibility

--- a/app/src/main/java/com/leohearts/alternativeUnlockHook/SettingsActivity.kt
+++ b/app/src/main/java/com/leohearts/alternativeUnlockHook/SettingsActivity.kt
@@ -109,7 +109,7 @@ fun listDivider(): Unit {
 }
 fun setPermission() {
 //    sudo("chown system:system /data/data/com.android.systemui/alternativePass.properties;setenforce 0;chcon u:object_r:platform_app:s0 /data/data/com.android.systemui/alternativePass.properties;setenforce 1")
-    sudo("chown `stat /data/data/com.android.systemui/ -c %u`:0 ${CONFIG_PATH}; chmod 644 ${CONFIG_PATH}")
+    sudo("chown `stat /data/data/com.android.systemui/ -c %u`:`stat /data/data/com.android.systemui/ -c %g` ${CONFIG_PATH}; chmod 660 ${CONFIG_PATH}")
 }
 fun saveConfig(config: Properties, scope: CoroutineScope, snackbarHostState: SnackbarHostState) {
     config.store(sudo("cat > ${CONFIG_PATH}").outputStream, "")

--- a/app/src/main/java/com/leohearts/alternativeUnlockHook/SettingsActivity.kt
+++ b/app/src/main/java/com/leohearts/alternativeUnlockHook/SettingsActivity.kt
@@ -109,7 +109,7 @@ fun listDivider(): Unit {
 }
 fun setPermission() {
 //    sudo("chown system:system /data/data/com.android.systemui/alternativePass.properties;setenforce 0;chcon u:object_r:platform_app:s0 /data/data/com.android.systemui/alternativePass.properties;setenforce 1")
-    sudo("chown `stat /data/data/com.android.systemui/ -c %u`:0 ${CONFIG_PATH}; chmod 770 ${CONFIG_PATH}")
+    sudo("chown `stat /data/data/com.android.systemui/ -c %u`:0 ${CONFIG_PATH}; chmod 644 ${CONFIG_PATH}")
 }
 fun saveConfig(config: Properties, scope: CoroutineScope, snackbarHostState: SnackbarHostState) {
     config.store(sudo("cat > ${CONFIG_PATH}").outputStream, "")


### PR DESCRIPTION
fix: execute commands via app broadcast to bypass system_server su restrictions

- Fix config file permissions (chmod 770 → 644) so system_server can read it
- Add CommandReceiver that executes the configured command as root via su
- Hook now sends a broadcast to the app instead of exec'ing directly from
  system_server, where Magisk blocks su due to SELinux/uid restrictions
- Replace silent exception swallowing with proper Log.e() in hook
